### PR TITLE
Add default theme to button model

### DIFF
--- a/core/_colors.scss
+++ b/core/_colors.scss
@@ -22,7 +22,7 @@ $gamma: (
   orange: (4: #fff9f2, 3: #ffd0b2, 2: #ffa166, 1: #ff914d, 0: #fc8032, -1: #994f22, -2: #662b00, -3: #4d2000),
   yellow: (4: #fcfbeb, 3: #ffebb2, 2: #ffd257, 1: #ffc21a, 0: #e4a600, -1: #8c5600, -2: #593700, -3: #402700),
   green:  (4: #edfff1, 3: #b1e6b2, 2: #6dc770, 1: #4bae50, 0: #269941, -1: #165926, -2: #10401b, -3: #0a2610),
-  blue:   (4: #edfcff, 3: #ccefff, 2: #8cc9ff, 1: #4ea6ed, 0: #177ed5, -1: #115c99, -2: #003d73, -3: #00294d),
+  blue:   (4: #edfcff, 3: #b3daf5, 2: #59b4ff, 1: #459de6, 0: #177ed5, -1: #1466b3, -2: #003d73, -3: #00294d),
   purple: (4: #f7f9ff, 3: #ddccff, 2: #bca6ff, 1: #8b4dff, 0: #7e00ff, -1: #471f99, -2: #400080, -3: #330066),
   pink:   (4: #fff5ff, 3: #ffccfc, 2: #fd99ff, 1: #fc66ff, 0: #fc23ff, -1: #971599, -2: #650e66, -3: #4b0b4d),
 ) !default;
@@ -80,7 +80,7 @@ $shadow-success:   color(green, 3) !default;
 $shadow-error:     color(red, 3) !default;
 $shadow-invalid:   color(red, 3) !default;
 $shadow-focused:   color(yellow, 3) !default;
-$blink-riched:     color(slate, 2) !default;
+$blink-riched:     color(blue, 1) !default;
 $blink-default:    color(slate, 3) !default;
 $blink-muted:      color(slate, 4) !default;
 $blink-disabled:   color(slate, 4) !default;
@@ -105,4 +105,4 @@ $underline-warning:   color(yellow) !default;
 $underline-success:   color(green) !default;
 $underline-error:     color(red) !default;
 $underline-invalid:   color(red) !default;
-$underline-focused:   color(yellow) !default;
+$underline-focused:   color(yellow, 1) !default;

--- a/core/_library.scss
+++ b/core/_library.scss
@@ -152,13 +152,16 @@
   @if (index($side, left)) {
     $stroke: set-nth($stroke, 4, $thin);
   }
-  @if ($side == ()) {
-    $stroke: $thin, -$thin, -$thin, $thin;
-  }
 
   $result: ();
-  $result: append($result, nth($stroke, 2) nth($stroke, 3) 0 0 $color inset, comma);
-  $result: append($result, nth($stroke, 4) nth($stroke, 1) 0 0 $color inset, comma);
+
+  @if(length($side) == 4 or length($side) == 0) {
+    $stroke: $thin, -$thin, -$thin, $thin;
+    $result: append($result, 0 0 0 $thin $color inset, comma);
+  } @else {
+    $result: append($result, nth($stroke, 2) nth($stroke, 1) 0 0 $color inset, comma);
+    $result: append($result, nth($stroke, 4) nth($stroke, 3) 0 0 $color inset, comma);
+  }
 
   @return (result: $result, stroke: $stroke);
 }
@@ -312,16 +315,6 @@
   &::-webkit-input-placeholder { @content }
   &::-moz-placeholder { @content }
   &:-ms-input-placeholder { @content }
-}
-
-// @ff-select-bugfix  Fix Firefox outline bug on select tag
-// $color             Color which would be applied to text
-//
-// @return            Fixed color style
-
-@mixin ff-select-bugfix($color) {
-  color: transparent;
-  text-shadow: 0 0 0 $color;
 }
 
 // @bug   the pattern to be embedded to wrong situations,

--- a/models/b-block/_manifest.scss
+++ b/models/b-block/_manifest.scss
@@ -12,6 +12,7 @@
   :which(muted) { background-color: $bg-muted; }
   :which(selected) { background-color: $bg-selected; }
   :which(hovered) { background-color: $bg-hovered; }
+  :which(activated) { background-color: $bg-activated; }
   :which(info) { background-color: $bg-info; }
   :which(warning) { background-color: $bg-warning; }
   :which(success) { background-color: $bg-success; }

--- a/models/btn-button/_manifest.scss
+++ b/models/btn-button/_manifest.scss
@@ -25,30 +25,32 @@ $button-disabled-color: text-color($text-disabled) !default;
   transition: color $animated;
   vertical-align: middle;
 
-  @each $state in $states-order {
-    @if $state == Focus {
-      @include state($state) {
-        color: $button-focus-color;
-      }
-    }
-    @elseif $state == Hover {
-      @include state($state) {
-        color: $button-hover-color;
-      }
-    }
-    @elseif $state == Active {
-      @include state($state) {
-        color: $button-active-color;
-        padding-top: $thin;
-      }
-    }
-    @elseif $state == Invalid {
-      @include state($state) {}
-    }
-    @elseif $state == Disabled {
-      @include state($state) {
-        color: $button-disabled-color;
-        pointer-events: none;
+  @include state(Active) {
+    padding-top: $thin;
+  }
+
+  @include state(Disabled) {
+    pointer-events: none;
+  }
+
+  &:not([class*="btn_theme-"]) {
+    @each $state in $states-order {
+      @if $state == Focus {
+        @include state($state) {
+          color: $button-focus-color;
+        }
+      } @else if $state == Hover {
+        @include state($state) {
+          color: $button-hover-color;
+        }
+      } @else if $state == Active {
+        @include state($state) {
+          color: $button-active-color;
+        }
+      } @else if $state == Disabled {
+        @include state($state) {
+          color: $button-disabled-color;
+        }
       }
     }
   }

--- a/models/cb-control-border/_manifest.scss
+++ b/models/cb-control-border/_manifest.scss
@@ -1,5 +1,5 @@
 $control-border-background: $bg-default !default;
-$control-border-text-color: text-color($text-default) !default;
+$control-border-text-color: text-color($text-riched) !default;
 $control-border-disabled-color: text-color($text-disabled) !default;
 $control-border-default-border: $border-default !default;
 $control-border-disabled-border: $border-disabled !default;
@@ -19,6 +19,7 @@ $control-border-invalid-underline: $underline-invalid !default;
     @include stroke($control-border-default-border, $underline: $control-border-default-underline);
     @include radius;
     background-color: inherit;
+    //color: $control-border-text-color; //No! Because it override disabled state from form-field
     flex-grow: 1;
     padding-left: size();
     padding-right: size();
@@ -29,6 +30,7 @@ $control-border-invalid-underline: $underline-invalid !default;
       @include radius(left);
       background-color: inherit;
       color: $control-border-text-color;
+      cursor: default;
       margin-right: size(-0.8);
       min-width: size(3);
       order: -1;

--- a/models/cu-control-underline/_manifest.scss
+++ b/models/cu-control-underline/_manifest.scss
@@ -7,12 +7,11 @@ $control-underline-focus-underline: $underline-focused !default;
 $control-underline-invalid-underline: $underline-invalid !default;
 
 :model(Control-Underline) {
-  @include radius;
   align-items: flex-start;
   display: flex;
   line-height: size(3);
 
-  :has(Field) {
+  :has(Control) {
     @include stroke($underline: $control-underline-default-underline);
     flex-grow: 1;
     padding-left: size();
@@ -22,6 +21,7 @@ $control-underline-invalid-underline: $underline-invalid !default;
     ~ :has(Icon) {
       @include stroke($underline: $control-underline-default-underline);
       color: $control-underline-text-color;
+      cursor: default;
       margin-right: size(-0.8);
       min-width: size(3);
       order: -1;

--- a/models/grp-group/_manifest.scss
+++ b/models/grp-group/_manifest.scss
@@ -7,6 +7,7 @@ $group-separator-color: $border-default !default;
   :has(Chunk) {
     height: size(3);
     line-height: size(3);
+    text-decoration: initial;
 
     &:not(:last-child) > [class] {
       border-bottom-right-radius: 0;

--- a/models/ls-list-switcher/_manifest.scss
+++ b/models/ls-list-switcher/_manifest.scss
@@ -1,26 +1,30 @@
-$list-switcher-arrow-color: $border-default !default;
-$list-switcher-text-color: text-color($text-default) !default;
-$list-switcher-hover-color: text-color($text-hovered) !default;
-$list-switcher-focus-color: text-color($text-focused) !default;
-$list-switcher-invalid-color: text-color($text-invalid) !default;
-$list-switcher-disabled-color: text-color($text-disabled) !default;
+$list-switcher-arrow-color: text-color($text-riched) !default;
+$list-switcher-disabled-arrow-color: text-color($text-disabled) !default;
+$list-switcher-default-text: text-color($text-default) !default;
 
 :model(List-switcher) {
   appearance: initial;
   background-color: initial;
   border: initial;
+  border-radius: initial;
   box-shadow: initial;
   font-family: inherit;
   margin: initial;
   outline: initial;
-  padding: initial;
+  padding-top: initial;
+  padding-bottom: initial;
+  padding-left: initial;
   text-decoration: initial;
   user-select: none;
 }
 
+_:-moz-tree-row(hover), :model(List-switcher) { //Fix Firefox bug
+  color: transparent;
+  text-shadow: 0 0 0 $list-switcher-default-text;
+}
+
 :model(List-switcher) {
-  @include ff-select-bugfix($list-switcher-text-color);
-  background-image: url("data:image/svg+xml;utf8, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 6 6'><path fill='#{html-encode(color-to-hex($list-switcher-text-color))}' d='M0 2 3 5 l3-3z'/></svg>");
+  background-image: url("data:image/svg+xml;utf8, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 6 6'><path fill='#{html-encode(color-to-hex($list-switcher-arrow-color))}' d='M0 2 3 5 l3-3z'/></svg>"); //TODO COLOR
   background-position: calc(100% - 10px) 45%;
   background-repeat: no-repeat;
   background-size: size();
@@ -29,10 +33,11 @@ $list-switcher-disabled-color: text-color($text-disabled) !default;
   height: size(3);
   line-height: size(3);
   overflow: hidden;
+  padding-right: size(2) !important;
   transition: color $animated, text-shadow $animated;
 
   :has(Option) {
-    color: $list-switcher-text-color;
+    color: text-color($text-riched); //TODO Refactoring
     font-size: inherit; //Should be same
     text-shadow: initial;
   }
@@ -40,7 +45,7 @@ $list-switcher-disabled-color: text-color($text-disabled) !default;
   @each $state in $states-order {
     @if $state == Disabled {
       @include state($state) {
-        background-image: url("data:image/svg+xml;utf8, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 6 6'><path fill='rgba(0,0,0,0)' stroke='#{html-encode(color-to-hex($list-switcher-disabled-color))}' d='M1 1 5 5 l-2-2 l-2 2 l4-4'/></svg>");
+        background-image: url("data:image/svg+xml;utf8, <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 6 6'><path fill='rgba(0,0,0,0)' stroke='#{html-encode(color-to-hex($list-switcher-disabled-arrow-color))}' d='M1 1 5 5 l-2-2 l-2 2 l4-4'/></svg>");
         pointer-events: none;
       }
     }

--- a/models/t-text/_manifest.scss
+++ b/models/t-text/_manifest.scss
@@ -6,6 +6,7 @@
 
   :which(riched) { color: text-color($text-riched); }
   :which(muted) { color: text-color($text-muted); }
+  :which(activated) { color: text-color($text-activated); }
   :which(selected) { color: text-color($text-selected); }
   :which(hovered) { color: text-color($text-hovered); }
   :which(info) { color: text-color($text-info); }

--- a/models/tf-text-field/_manifest.scss
+++ b/models/tf-text-field/_manifest.scss
@@ -1,8 +1,3 @@
-$text-field-text-color: text-color($text-default) !default;
-$text-field-focus-color: text-color($text-focused) !default;
-$text-field-hover-color: text-color($text-hovered) !default;
-$text-field-active-color: text-color($text-activated) !default;
-$text-field-invalid-color: text-color($text-invalid) !default;
 $text-field-disabled-color: text-color($text-disabled) !default;
 $text-field-placeholder-opacity: 0.8 !default;
 
@@ -20,7 +15,6 @@ $text-field-placeholder-opacity: 0.8 !default;
 
 :model(Text-field) {
   -webkit-text-fill-color: currentColor;
-  color: $text-field-text-color;
   cursor: text;
   font-size: $font-size-small;
   height: size(3);


### PR DESCRIPTION
Update blue color
Update blink-riched color
Update underline-focused color
Improve stroke-border line with corner radius
Add activated background to block model
Exclude color from control models
Reset cursor to default on control icons
Remove underline from group chunk if it link
Remove corner-radius from default select in list-switcher model
Reset padding exclude padding-right in list-switcher model
Remove firefox-bugfix mixin from library to list-switcher model
Set padding-right with important for customization arrow
Delete unnecessary color defines in list-switcher model
Add activated color to text model